### PR TITLE
CLM-17 | write attendances migration and enum

### DIFF
--- a/db/migrate/20240814063543_create_attendance.rb
+++ b/db/migrate/20240814063543_create_attendance.rb
@@ -1,0 +1,13 @@
+class CreateAttendance < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :status, ['Going', 'Maybe', "Can't Go"]
+
+    create_table :attendances do |t|
+      t.references :event, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.enum :attendance_status, enum_type: 'status', null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_004215) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "status", ["Going", "Maybe", "Can't Go"]
   create_enum "type", ["public", "private", "friends only"]
+
+  create_table "attendances", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.bigint "user_id", null: false
+    t.enum "attendance_status", null: false, enum_type: "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_attendances_on_event_id"
+    t.index ["user_id"], name: "index_attendances_on_user_id"
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "name", default: "", null: false
@@ -37,4 +48,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_004215) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "attendances", "events"
+  add_foreign_key "attendances", "users"
 end


### PR DESCRIPTION
This table takes in 2 foreign keys event and user
Also has a attendance status which is defined in the enum :status